### PR TITLE
changed search event from keyup to input

### DIFF
--- a/src/views/todo.vue
+++ b/src/views/todo.vue
@@ -35,7 +35,7 @@
                     <i class="fa-solid fa-arrow-left-long"></i>
                 </div>
                 <div class="w-75">
-                <input class="form-control" v-model="searchName" @keyup="searchTodos" type="search" placeholder="Search todos....." aria-label="Search">
+                <input class="form-control" v-model="searchName" @input="searchTodos" type="search" placeholder="Search todos....." aria-label="Search">
                 </div>
             </div>
 


### PR DESCRIPTION
i changed the search event from keyup to input due to the fact that the keyup event does not work on mobile phones which would affect the search event triggering and cause bad user experience. This is because the mobile phone does not have a real keyboard but a virtual one.